### PR TITLE
demo the failure issue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
           NIGHTWATCH_HEADLESS: true
           CUCUMBER_PUBLISH_ENABLED: true
           CN_DEBUG: true
+          NIGHTWATCH_OUTPUT: true
 
   test-serial:
     runs-on: ubuntu-latest
@@ -51,3 +52,4 @@ jobs:
           NIGHTWATCH_HEADLESS: true
           CUCUMBER_PUBLISH_ENABLED: true
           CN_DEBUG: true
+          NIGHTWATCH_OUTPUT: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - run: npm ci
-      - run: npm run test -- --tags "@google" --retry 2 --parallel 4
+      - run: npm run test -- --tags "@fail" --retry 2 --parallel 4
         env:
           NIGHTWATCH_HEADLESS: true
           CUCUMBER_PUBLISH_ENABLED: true
@@ -46,7 +46,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - run: npm ci
-      - run: npm run test -- --tags "@google"
+      - run: npm run test -- --tags "@fail"
         env:
           NIGHTWATCH_HEADLESS: true
           CUCUMBER_PUBLISH_ENABLED: true

--- a/features/googleSearch.feature
+++ b/features/googleSearch.feature
@@ -5,6 +5,10 @@ Background: Background name
   Given I open the url "https://google.com"
   Then I expect that the title is "Google"
 
+@fail
+Scenario: should fail
+  When I looking for a not existing element
+
 @google
 Scenario: Searching Google for Nightwatch
   When I set "nightwatchjs" to the inputfield "input[name=q]"

--- a/features/step_definitions/steps.ts
+++ b/features/step_definitions/steps.ts
@@ -12,7 +12,7 @@ When(
   }
 )
 
-When(/^I press "([^"]*)?"$/, async function (key: string) {
+When(/^I press "([^"]*)?"$/, async function (this: World, key: string) {
   /* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return */
   await this.browser!.perform(function (this: any) {
     const actions = this.actions({ async: true })
@@ -20,6 +20,36 @@ When(/^I press "([^"]*)?"$/, async function (key: string) {
     return actions.keyDown(this.Keys[key]).keyUp(this.Keys[key])
   })
   /* eslint-enable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return */
+})
+
+When(/^I looking for a not existing element$/, async function (this: World) {
+  try {
+    // These won't throw an error
+    await this.browser!.waitForElementVisible(
+      '#not-existing-element',
+      1000,
+      0,
+      true,
+      function (result) {
+        console.log('result', result)
+      }
+    )
+    await this.browser!.waitForElementPresent(
+      'css selector',
+      '#not-existing-element'
+    )
+    // await this.browser!.click('#not-existing-element')
+    // await this.browser!.ensure.elementIsVisible('#not-existing-element')
+
+    // Below works fine
+    // await this.browser!.expect.element('#not-existing-element').to.be.present;
+    // await this.browser!.expect.element('#not-existing-element').to.be.visible;
+    // await this.browser!.assert.visible('#not-existing-element')
+    console.log('No error has been caught')
+  } catch (error) {
+    console.log('We expect error from failed command: ', error)
+    throw new Error('Expected error has been caught')
+  }
 })
 
 Then(

--- a/features/support/NightwatchWorld.ts
+++ b/features/support/NightwatchWorld.ts
@@ -17,7 +17,7 @@ const nightwatchClient = function () {
     output: process.env.NIGHTWATCH_OUTPUT === 'true',
     silent: !(process.env.NIGHTWATCH_SILENT === 'false'), // set to false to enable verbose logging
     browserName: process.env.NIGHTWATCH_BROWSER, // can be either: firefox, chrome, safari, or edge
-
+    always_async_commands: true,
     // set the global timeout to be used with waitFor commands and when retrying assertions/expects
     timeout: process.env.NIGHTWATCH_TIMEOUT || 10000,
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@types/node": "^18.11.7",
         "@typescript-eslint/eslint-plugin": "^5.43.0",
         "@typescript-eslint/parser": "^5.43.0",
-        "chromedriver": "^106.0.0",
+        "chromedriver": "^108.0.0",
         "dotenv": "^16.0.3",
         "eslint": "^8.28.0",
         "eslint-config-prettier": "^8.5.0",
@@ -817,18 +817,6 @@
         "node": ">= 6.0.0"
       }
     },
-    "node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -973,12 +961,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.1.tgz",
+      "integrity": "sha512-I88cFiGu9ryt/tfVEi4kX2SITsvDddTajXTOFmt2uK1ZVA8LytjtdeyefdQWEf5PU8w+4SSJDoYnggflB5tW4A==",
       "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1247,15 +1236,14 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "106.0.1",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-106.0.1.tgz",
-      "integrity": "sha512-thaBvbDEPgGocSp4/SBIajQz3G7UQfUqCOHZBp9TVhRJv7c91eZrUGcjeJUaNF4p9CfSjCYNYzs4EVVryqmddA==",
+      "version": "108.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-108.0.0.tgz",
+      "integrity": "sha512-/kb0rb0dlC4RfXh2BOT7RV87K6d+It3VV5YXebLzO5a8t2knNffiTE23XPJQCH+l1xmgoW8/sOX/NB9irskvOQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@testim/chrome-version": "^1.1.3",
-        "axios": "^0.27.2",
+        "axios": "^1.1.3",
         "compare-versions": "^5.0.1",
-        "del": "^6.1.1",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^1.1.0",
@@ -1265,7 +1253,7 @@
         "chromedriver": "bin/chromedriver"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/ci-info": {
@@ -1277,14 +1265,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
-    },
-    "node_modules/clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/cli-boxes": {
       "version": "2.2.1",
@@ -1529,27 +1509,6 @@
       "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/del": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/del/-/del-6.1.1.tgz",
-      "integrity": "sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==",
-      "dependencies": {
-        "globby": "^11.0.1",
-        "graceful-fs": "^4.2.4",
-        "is-glob": "^4.0.1",
-        "is-path-cwd": "^2.2.0",
-        "is-path-inside": "^3.0.2",
-        "p-map": "^4.0.0",
-        "rimraf": "^3.0.2",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/delayed-stream": {
@@ -2633,14 +2592,6 @@
         "node": ">=0.12.0"
       }
     },
-    "node_modules/is-path-cwd": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -3551,20 +3502,6 @@
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dependencies": {
         "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-map": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "dependencies": {
-        "aggregate-error": "^3.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -5168,15 +5105,6 @@
         "debug": "4"
       }
     },
-    "aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "requires": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      }
-    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -5284,12 +5212,13 @@
       "integrity": "sha512-4+rr8eQ7+XXS5nZrKcMO/AikHL0hVqy+lHWAnE3xdHl+aguag8SOQ6eEqLexwLNWgXIMfunGuD3ON1/6Kyet0A=="
     },
     "axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.1.tgz",
+      "integrity": "sha512-I88cFiGu9ryt/tfVEi4kX2SITsvDddTajXTOFmt2uK1ZVA8LytjtdeyefdQWEf5PU8w+4SSJDoYnggflB5tW4A==",
       "requires": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "balanced-match": {
@@ -5470,14 +5399,13 @@
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
     },
     "chromedriver": {
-      "version": "106.0.1",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-106.0.1.tgz",
-      "integrity": "sha512-thaBvbDEPgGocSp4/SBIajQz3G7UQfUqCOHZBp9TVhRJv7c91eZrUGcjeJUaNF4p9CfSjCYNYzs4EVVryqmddA==",
+      "version": "108.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-108.0.0.tgz",
+      "integrity": "sha512-/kb0rb0dlC4RfXh2BOT7RV87K6d+It3VV5YXebLzO5a8t2knNffiTE23XPJQCH+l1xmgoW8/sOX/NB9irskvOQ==",
       "requires": {
         "@testim/chrome-version": "^1.1.3",
-        "axios": "^0.27.2",
+        "axios": "^1.1.3",
         "compare-versions": "^5.0.1",
-        "del": "^6.1.1",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^1.1.0",
@@ -5493,11 +5421,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
-    },
-    "clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
     },
     "cli-boxes": {
       "version": "2.2.1",
@@ -5672,21 +5595,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
       "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="
-    },
-    "del": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/del/-/del-6.1.1.tgz",
-      "integrity": "sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==",
-      "requires": {
-        "globby": "^11.0.1",
-        "graceful-fs": "^4.2.4",
-        "is-glob": "^4.0.1",
-        "is-path-cwd": "^2.2.0",
-        "is-path-inside": "^3.0.2",
-        "p-map": "^4.0.0",
-        "rimraf": "^3.0.2",
-        "slash": "^3.0.0"
-      }
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -6451,11 +6359,6 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
-    "is-path-cwd": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ=="
-    },
     "is-path-inside": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -7165,14 +7068,6 @@
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "requires": {
         "p-limit": "^3.0.2"
-      }
-    },
-    "p-map": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "requires": {
-        "aggregate-error": "^3.0.0"
       }
     },
     "pad-right": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@types/node": "^18.11.7",
     "@typescript-eslint/eslint-plugin": "^5.43.0",
     "@typescript-eslint/parser": "^5.43.0",
-    "chromedriver": "^106.0.0",
+    "chromedriver": "^108.0.0",
     "dotenv": "^16.0.3",
     "eslint": "^8.28.0",
     "eslint-config-prettier": "^8.5.0",


### PR DESCRIPTION
In my setup(Nightwatch programmatic API with cucumber-js), the Nightwatch API command won't fail the step, even if they do get the error.
`Assert` and `Expect` work as expected. If I use `try catch`, I can catch the error.

See the CI result: https://github.com/nightwatchjs-community/cucumber-nightwatch/actions/runs/3547793604/jobs/5958303663

To reproduce the issue, run 
```
NIGHTWATCH_OUTPUT=true npm run test -- --tags "@fail"
```
The issue can't be reproduced in https://github.com/nightwatchjs/cucumberjs-boilerplate. So I guess something with my setup but really need some help to debug. 
